### PR TITLE
Feature/mount config support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,11 +11,12 @@ import (
 )
 
 type Config struct {
-	Name      string     `yaml:"name"`
-	PHP       string     `yaml:"php"`
-	CPUs      string     `yaml:"cpus"`
-	Disk      string     `yaml:"disk"`
-	Memory    string     `yaml:"memory"`
+	Name      string `yaml:"name"`
+	PHP       string `yaml:"php"`
+	CPUs      string `yaml:"cpus"`
+	Disk      string `yaml:"disk"`
+	Memory    string `yaml:"memory"`
+	Mounts    []Mount `yaml:"mounts"`
 	Databases []Database `yaml:"databases"`
 	Sites     []Site     `yaml:"sites"`
 }

--- a/config/mounts.go
+++ b/config/mounts.go
@@ -1,0 +1,6 @@
+package config
+
+type Mount struct {
+	Source      string `yaml:"source"`
+	Destination string `yaml:"destination"`
+}

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -21,6 +21,13 @@ func Mount(name, folder, site string) (*Action, error) {
 }
 
 func MountDirectory(name, source, destination string) (*Action, error) {
+	if err := validate.MachineName(name); err != nil {
+		return nil, err
+	}
+	if err := validate.Path(source); err != nil {
+		return nil, err
+	}
+
 	return &Action{
 		Type:       "mount",
 		UseSyscall: false,

--- a/internal/action/mount.go
+++ b/internal/action/mount.go
@@ -19,3 +19,11 @@ func Mount(name, folder, site string) (*Action, error) {
 		Args:       []string{"mount", folder, name + ":/app/sites/" + site},
 	}, nil
 }
+
+func MountDirectory(name, source, destination string) (*Action, error) {
+	return &Action{
+		Type:       "mount",
+		UseSyscall: false,
+		Args:       []string{"mount", source, name + ":" + destination},
+	}, nil
+}

--- a/internal/action/mount_test.go
+++ b/internal/action/mount_test.go
@@ -75,3 +75,64 @@ func TestMount(t *testing.T) {
 		})
 	}
 }
+
+func TestMountDirectory(t *testing.T) {
+	type args struct {
+		name        string
+		source      string
+		destination string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Action
+		wantErr bool
+	}{
+		{
+			name: "valid args returns action",
+			args: args{
+				name:        "somename",
+				source:      "/tmp",
+				destination: "/home/ubuntu/sites/test",
+			},
+			want: &Action{
+				Type:       "mount",
+				UseSyscall: false,
+				Args:       []string{"mount", "/tmp", "somename:/home/ubuntu/sites/test"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid source returns error",
+			args: args{
+				name:        "somename",
+				source:      "not-here",
+				destination: "/home/ubuntu/dev",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid name returns error",
+			args: args{
+				name:        "",
+				source:      "/tmp",
+				destination: "/home/ubuntu/dev",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MountDirectory(tt.args.name, tt.args.source, tt.args.destination)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MountDirectory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MountDirectory() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/machine_create.go
+++ b/internal/cmd/machine_create.go
@@ -209,24 +209,12 @@ var createCommand = &cobra.Command{
 
 		if flagDebug {
 			fmt.Println("---- COMMANDS ----")
+
 			for _, a := range actions {
 				fmt.Println(a.Args)
 			}
-			fmt.Printf("---- %d TOTAL COMMANDS ----", len(actions))
 
-			//fmt.Println("---- CONFIG FILE ----")
-			//
-			//var configFile config.Config
-			//if err := viper.Unmarshal(&configFile); err != nil {
-			//	return err
-			//}
-			//
-			//configData, err := yaml.Marshal(configFile)
-			//if err != nil {
-			//	return err
-			//}
-			//
-			//fmt.Println(string(configData))
+			fmt.Printf("---- %d TOTAL COMMANDS ----", len(actions))
 
 			return nil
 		}

--- a/internal/cmd/site_remove.go
+++ b/internal/cmd/site_remove.go
@@ -93,7 +93,7 @@ var siteRemoveCommand = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("removed %q from %q", site, name)
+		fmt.Printf("removed %q from %q\n", site, name)
 
 		return nil
 	},

--- a/nitro.yaml
+++ b/nitro.yaml
@@ -1,5 +1,5 @@
 name: nitro-local
-cpus: 2
+cpus: 1
 memory: 4G
 disk: 40G
 php: 7.4

--- a/nitro.yaml
+++ b/nitro.yaml
@@ -21,5 +21,5 @@ sites:
     path: ~/dev/plugins-dev # maps to /apps/sites/anotherproject.test
     docroot: web
   - domain: clientname.test
-    path: ~/clientname/prodution-site # maps to /apps/sites/prodution-site.test
+    path: ~/clientname/production-site # maps to /apps/sites/production-site.test
     docroot: web


### PR DESCRIPTION
Can I get an extra set of eyes on this? There are not a lot of tests for the command yet (will spend a day working those in later, once the structure is flushed out) but this adds support for `mounts` in a configuration file.

A few things to check:

1. If the config files does not have mounts, it should operate as normal
2. If the config file has mounts and the sites path looks similar, we don't mount the sites path, but we still create the vhost
